### PR TITLE
Update BinaryBuilder::Resize(int64_t capacity) in builder.cc

### DIFF
--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1223,6 +1223,7 @@ Status BinaryBuilder::Resize(int64_t capacity) {
   DCHECK_LT(capacity, std::numeric_limits<int32_t>::max());
   // one more then requested for offsets
   RETURN_NOT_OK(offsets_builder_.Resize((capacity + 1) * sizeof(int64_t)));
+  RETURN_NOT_OK(value_data_builder_.Resize(capacity));
   return ArrayBuilder::Resize(capacity);
 }
 


### PR DESCRIPTION
When building BinaryArrays with a known size using Resize and Reserve methods, space is also reserved for value_data_builder_ to prevent internal reallocation