### PR TITLE
Update ReserveData(int64_t) method for BinaryBuilder

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1158,7 +1158,7 @@ TEST_F(TestBinaryBuilder, TestScalarAppend) {
 TEST_F(TestBinaryBuilder, TestCapacityReserve) {
   vector<string> strings = {"a", "bb", "cc", "ddddd", "eeeee"};
   int64_t N = static_cast<int>(strings.size());
-  int64_t length = 0
+  int64_t length = 0;
   int64_t data_length = 0;
   int64_t capacity = N;
  

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1154,6 +1154,55 @@ TEST_F(TestBinaryBuilder, TestScalarAppend) {
     }
   }
 }
+ 
+TEST_F(TestBinaryBuilder, TestCapacityReserve) {
+  vector<string> strings = {"a", "bb", "cc", "ddddd", "eeeee"};
+  int N = static_cast<int>(strings.size());
+  int length = 0
+  int data_length = 0;
+  int capacity = N;
+ 
+  ASSERT_OK(builder_->Reserve(capacity));
+  ASSERT_OK(builder_->ReserveData(capacity));
+  
+  ASSERT_EQ(static_cast<int>(builder_->length()), length);
+  ASSERT_EQ(static_cast<int>(builder_->capacity()), capacity);
+  ASSERT_EQ(static_cast<int>(builder_->value_data_length()), data_length);
+  ASSERT_EQ(static_cast<int>(builder_->value_data_capacity()), capacity);
+ 
+  for(const string& str : strings) {
+    ASSERT_OK(builder_->Append(str));
+   
+    length++;
+    data_length += static_cast<int>(str.size());
+   
+    ASSERT_EQ(static_cast<int>(builder_->length()), length);
+    ASSERT_EQ(static_cast<int>(builder_->capacity()), capacity);
+    ASSERT_EQ(static_cast<int>(builder_->value_data_length()), data_length);
+    if(data_length <= capacity) {
+      ASSERT_EQ(static_cast<int>(builder_->value_data_capacity()), capacity);
+    } else {
+      ASSERT_EQ(static_cast<int>(builder_->value_data_capacity()), data_length);
+    }
+  }
+ 
+  int extra_capacity = 10;
+ 
+  ASSERT_OK(builder_->Reserve(extra_capacity));
+  ASSERT_OK(builder_->ReserveData(extra_capacity));
+ 
+  ASSERT_EQ(static_cast<int>(builder_->length()), length);
+  ASSERT_EQ(static_cast<int>(builder_->capacity()), length + extra_capacity);
+  ASSERT_EQ(static_cast<int>(builder_->value_data_length()), data_length);
+  ASSERT_EQ(static_cast<int>(builder_->value_data_capacity()), data_length + extra_capacity);
+ 
+  Done();
+  
+  ASSERT_EQ(N, result_->length());
+  ASSERT_EQ(0, result_->null_count());
+  ASSERT_EQ(data_length, result_->value_data()->size());
+  ASSERT_EQ(data_length + extra_capacity, result_->value_data()->capacity());
+}
 
 TEST_F(TestBinaryBuilder, TestZeroLength) {
   // All buffers are null

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1157,51 +1157,50 @@ TEST_F(TestBinaryBuilder, TestScalarAppend) {
  
 TEST_F(TestBinaryBuilder, TestCapacityReserve) {
   vector<string> strings = {"a", "bb", "cc", "ddddd", "eeeee"};
-  int N = static_cast<int>(strings.size());
-  int length = 0
-  int data_length = 0;
-  int capacity = N;
+  int64_t N = static_cast<int>(strings.size());
+  int64_t length = 0
+  int64_t data_length = 0;
+  int64_t capacity = N;
  
   ASSERT_OK(builder_->Reserve(capacity));
   ASSERT_OK(builder_->ReserveData(capacity));
   
-  ASSERT_EQ(static_cast<int>(builder_->length()), length);
-  ASSERT_EQ(static_cast<int>(builder_->capacity()), capacity);
-  ASSERT_EQ(static_cast<int>(builder_->value_data_length()), data_length);
-  ASSERT_EQ(static_cast<int>(builder_->value_data_capacity()), capacity);
+  ASSERT_EQ(builder_->length(), length);
+  ASSERT_EQ(builder_->capacity(), BitUtil::NextPower2(capacity));
+  ASSERT_EQ(builder_->value_data_length(), data_length);
+  ASSERT_EQ(builder_->value_data_capacity(), capacity);
  
   for(const string& str : strings) {
     ASSERT_OK(builder_->Append(str));
-   
     length++;
     data_length += static_cast<int>(str.size());
    
-    ASSERT_EQ(static_cast<int>(builder_->length()), length);
-    ASSERT_EQ(static_cast<int>(builder_->capacity()), capacity);
-    ASSERT_EQ(static_cast<int>(builder_->value_data_length()), data_length);
-    if(data_length <= capacity) {
-      ASSERT_EQ(static_cast<int>(builder_->value_data_capacity()), capacity);
+    ASSERT_EQ(builder_->length(), length);
+    ASSERT_EQ(builder_->capacity(), BitUtil::NextPower2(capacity));
+    ASSERT_EQ(builder_->value_data_length(), data_length);
+    if (data_length <= capacity) {
+      ASSERT_EQ(builder_->value_data_capacity(), capacity);
     } else {
-      ASSERT_EQ(static_cast<int>(builder_->value_data_capacity()), data_length);
+      ASSERT_EQ(builder_->value_data_capacity(), data_length);
     }
   }
  
-  int extra_capacity = 10;
+  int extra_capacity = 20;
  
   ASSERT_OK(builder_->Reserve(extra_capacity));
   ASSERT_OK(builder_->ReserveData(extra_capacity));
  
-  ASSERT_EQ(static_cast<int>(builder_->length()), length);
-  ASSERT_EQ(static_cast<int>(builder_->capacity()), length + extra_capacity);
-  ASSERT_EQ(static_cast<int>(builder_->value_data_length()), data_length);
-  ASSERT_EQ(static_cast<int>(builder_->value_data_capacity()), data_length + extra_capacity);
+  ASSERT_EQ(builder_->length(), length);
+  ASSERT_EQ(builder_->capacity(), BitUtil::NextPower2(length + extra_capacity));
+  ASSERT_EQ(builder_->value_data_length(), data_length);
+  ASSERT_EQ(builder_->value_data_capacity(), data_length + extra_capacity);
  
   Done();
   
-  ASSERT_EQ(N, result_->length());
-  ASSERT_EQ(0, result_->null_count());
-  ASSERT_EQ(data_length, result_->value_data()->size());
-  ASSERT_EQ(data_length + extra_capacity, result_->value_data()->capacity());
+  ASSERT_EQ(result_->length(), N);
+  ASSERT_EQ(result_->null_count(), 0);
+  ASSERT_EQ(result_->value_data()->size(), data_length);
+  ASSERT_EQ(result_->value_data()->capacity(), BitUtil::RoundUpToMultipleOf64(data_length + extra_capacity));
 }
 
 TEST_F(TestBinaryBuilder, TestZeroLength) {

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1227,8 +1227,11 @@ Status BinaryBuilder::Resize(int64_t capacity) {
 }
   
 Status BinaryBuilder::ReserveData(int64_t capacity) {
-  DCHECK_LT(capacity, std::numeric_limits<int32_t>::max());
-  return value_data_builder_.Resize(capacity * sizeof(int64_t));
+  if(value_data_length.length() + capacity > std::numeric_limits<int32_t>::max()) {
+      return Status::Invalid("Cannot reserve capacity larger than 2^31 - 1 in length for binary data");
+  }
+  
+  return value_data_builder_.Resize(value_data_length.length() + capacity);
 }
 
 Status BinaryBuilder::AppendNextOffset() {

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1227,11 +1227,11 @@ Status BinaryBuilder::Resize(int64_t capacity) {
 }
   
 Status BinaryBuilder::ReserveData(int64_t capacity) {
-  if(value_data_length.length() + capacity > std::numeric_limits<int32_t>::max()) {
+  if(value_data_length() + capacity > std::numeric_limits<int32_t>::max()) {
       return Status::Invalid("Cannot reserve capacity larger than 2^31 - 1 in length for binary data");
   }
   
-  return value_data_builder_.Resize(value_data_length.length() + capacity);
+  return value_data_builder_.Resize(value_data_length() + capacity);
 }
 
 Status BinaryBuilder::AppendNextOffset() {

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -682,7 +682,7 @@ class ARROW_EXPORT BinaryBuilder : public ArrayBuilder {
 
   Status Init(int64_t elements) override;
   Status Resize(int64_t capacity) override;
-  Status ReserveData(int64_t bytes);
+  Status ReserveData(int64_t capacity);
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
   /// \return size of values buffer so far

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -688,7 +688,7 @@ class ARROW_EXPORT BinaryBuilder : public ArrayBuilder {
   /// \return size of values buffer so far
   int64_t value_data_length() const { return value_data_builder_.length(); }
   /// \return capacity of values buffer
-  int64_t value_data_capacity() const { return value_data_builder_.capacity(); }
+  int64_t value_data_capacity() const { return data_capacity_; }
 
   /// Temporary access to a value.
   ///
@@ -699,6 +699,7 @@ class ARROW_EXPORT BinaryBuilder : public ArrayBuilder {
   TypedBufferBuilder<int32_t> offsets_builder_;
   TypedBufferBuilder<uint8_t> value_data_builder_;
 
+  int64_t data_capacity_;
   static constexpr int64_t kMaximumCapacity = std::numeric_limits<int32_t>::max() - 1;
 
   Status AppendNextOffset();


### PR DESCRIPTION
Calling ReserveData means requesting extra capacity for value_data_builder_ so its current length is added as the total wanted capacity.